### PR TITLE
Feature/Sam - our story responsive

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,40 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from '../src/Components/Theme';
 import { GlobalStyle } from '../src/vendor/fonts/fonts';
 
+/**
+ * 
+ * @author [J. Hartsek](https://github.com/JHartsek),
+ * Added `customViewports`: @author [Sam](https://github.com/Samm96)
+ *
+ */
+
+export const customViewports = {
+  Desktop: {
+      name: "Large",
+      styles: {
+          width: "1440px",
+          height: "100%",
+      },
+      type: 'Desktop',
+  },
+  Smaller_Desktop: {
+      name: "Medium",
+      styles: {
+          width: "1024px",
+          height: "100%",
+      },
+      type: 'Smaller Desktop',
+  },
+  iPhone_Mini: {
+      name: "Small",
+      styles: {
+          width: "375px",
+          height: "100%",
+      },
+      type: 'iPhone Mini',
+  },
+};
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -15,8 +49,13 @@ export const parameters = {
     storySort: {
       method: 'alphabetical'
     }
+  },
+  viewport: {
+    viewports: {
+      viewports: customViewports
+    },
   }
-}
+};
 
 export const decorators = [
   (Story) => (

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -1,11 +1,9 @@
-
 import styled from "styled-components";
 import Team from "./Team";
 import { motion } from "framer-motion";
 import { sectionVariants } from "../utils/animationVariants";
 import Content from "../Components/Content";
 import { data } from "../utils/data";
-
 
 /**
  * The Our Story Component
@@ -21,23 +19,47 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   margin: 0 auto;
   padding: 80px 80px 210px 80px;
 
+  @media (max-width: 1024px) {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 80px 40px 210px 40px;
+  }
+
   &.story {
     background-color: transparent;
     max-width: 1281px;
+    width: 100%;
     padding: 0;
     display: flex;
     justify-content: space-between;
+
+    @media (max-width: 1024px) {
+      max-width: 1024px;
+    }
+  }
+
+  &.story__content {
+    padding: 0;
   }
 
   &.story__founder {
     background-color: transparent;
-    max-width: 608px;
+    max-width: 620px;
     margin: 88px 0 0 0;
     padding: 0;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gird-template-rows: 1fr 1fr;
     grid-gap: 16px;
+
+    @media (max-width: 1024px) {
+      max-width: 1024px;
+      margin: 80px 0 0 0;
+      justify-self: flex-end;
+      grid-template-columns: 1fr;
+      grid-gap: 16px 0;
+    }
   }
 
   &.team__container {
@@ -61,6 +83,12 @@ const Text = styled.p.attrs(() => ({ tabIndex: 0 }))`
     font-style: ${(props) => `${props.theme.fonts.text.styles}`};
     width: 608px;
     line-height: 22px;
+
+    @media (max-width: 1024px) {
+      max-width: 561px;
+      width: 100%;
+      margin: 0 0 0 12px;
+    }
   }
 
   &.story__founder-name {
@@ -72,7 +100,8 @@ const Text = styled.p.attrs(() => ({ tabIndex: 0 }))`
 const Line = styled.span`
   border-left: 2px solid
     ${(props) => `${props.theme.colors.default_text_color}`};
-  height: 132px;
+  height: 100%;
+  justify-self: end;
 `;
 
 const OurStory = () => {
@@ -84,14 +113,13 @@ const OurStory = () => {
       initial="offscreen"
       whileInView="onscreen"
     >
-
-      {/* replace with Content component*/}
-     
       <Container className="story">
-      <Content
-        header={data.content.ourStory.header}
-        details={data.content.ourStory.paragraphs}
-      />
+        <Container className="story__content">
+          <Content
+            header={data.content.ourStory.header}
+            details={data.content.ourStory.paragraphs}
+          />
+        </Container>
         <Container className="story__founder">
           <Line></Line>
           <Text className="story__founder-quote">

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -19,7 +19,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   margin: 0 auto;
   padding: 80px 80px 210px 80px;
 
-  @media (max-width: 1024px) {
+  @media (max-width: 1200px) {
     display: flex;
     flex-direction: column;
     margin: 0;
@@ -38,7 +38,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     display: flex;
     justify-content: space-between;
 
-    @media (max-width: 1024px) {
+    @media (max-width: 1200px) {
       max-width: 1024px;
     }
   }
@@ -58,7 +58,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     gird-template-rows: 1fr 1fr;
     grid-gap: 16px;
 
-    @media (max-width: 1024px) {
+    @media (max-width: 1200px) {
       max-width: 1024px;
       margin: 80px 0 0 0;
       justify-self: flex-end;

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -23,7 +23,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     display: flex;
     flex-direction: column;
     margin: 0;
-    padding: 80px 40px 210px 40px;
+    padding: 80px 40px 200px 40px;
   }
 
   &.story {
@@ -40,6 +40,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   }
 
   &.story__content {
+    margin: 0 40px 0 0;
     padding: 0;
   }
 

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -16,14 +16,14 @@ import { data } from "../utils/data";
 
 const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   background-color: ${(props) => `${props.theme.colors.primary_background}`};
-  max-width: 1440px;
-  width: 1281px;
+  max-width: 100%;
   height: fit-content;
   margin: 0 auto;
-  padding: 80px 80px 85px 80px;
+  padding: 80px 80px 210px 80px;
 
   &.story {
     background-color: transparent;
+    max-width: 1281px;
     padding: 0;
     display: flex;
     justify-content: space-between;
@@ -41,8 +41,10 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   }
 
   &.team__container {
+    background-color: transparent;
+    max-width: 1281px;
     width: fit-content;
-    margin: 120px 0 20px 0;
+    margin: 120px auto 0;
     padding: 0;
   }
 `;

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -65,8 +65,6 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
       grid-template-columns: 1fr;
       grid-gap: 16px 0;
     }
-
-    
   }
 
   &.team__container {

--- a/src/Components/OurStory.js
+++ b/src/Components/OurStory.js
@@ -26,6 +26,10 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     padding: 80px 40px 200px 40px;
   }
 
+  @media (max-width: 375px) {
+    padding: 100px 16px 100px 16px;
+  }
+
   &.story {
     background-color: transparent;
     max-width: 1281px;
@@ -61,6 +65,8 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
       grid-template-columns: 1fr;
       grid-gap: 16px 0;
     }
+
+    
   }
 
   &.team__container {
@@ -69,6 +75,14 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     width: fit-content;
     margin: 120px auto 0;
     padding: 0;
+
+    @media (max-width: 1024px) {
+      margin: 82px auto 0;
+    }
+
+    @media (max-width: 375px) {
+      margin: 40px auto 0;
+    }
   }
 `;
 
@@ -90,11 +104,19 @@ const Text = styled.p.attrs(() => ({ tabIndex: 0 }))`
       width: 100%;
       margin: 0 0 0 12px;
     }
+
+    @media (max-width: 375px) {
+      max-width: 343px;
+    }
   }
 
   &.story__founder-name {
     text-align: right;
     grid-column: 2;
+
+    @media (max-width: 375px) {
+      font-size: ${(props) => `${props.theme.fonts.text.sizes.text_s}`};
+    }
   }
 `;
 

--- a/src/Components/Team.js
+++ b/src/Components/Team.js
@@ -15,6 +15,7 @@ const Container = styled.div`
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: auto;
     grid-gap: 90px 100px;
+    background-color: transparent;
 `;
 
 const Team = () => {

--- a/src/Components/Team.js
+++ b/src/Components/Team.js
@@ -16,6 +16,11 @@ const Container = styled.div`
     grid-template-rows: auto;
     grid-gap: 90px 100px;
     background-color: transparent;
+
+    @media (max-width: 1024px) {
+      grid-template-columns: repeat(3, 1fr);
+      grid-gap: 95px 100px;
+    }
 `;
 
 const Team = () => {

--- a/src/Components/Team.js
+++ b/src/Components/Team.js
@@ -21,6 +21,11 @@ const Container = styled.div`
       grid-template-columns: repeat(3, 1fr);
       grid-gap: 95px 100px;
     }
+
+    @media (max-width: 640px) {
+      grid-template-columns: repeat(2, 1fr);
+      grid-gap: 40px 11px;
+    }
 `;
 
 const Team = () => {

--- a/src/Components/TeamMember.js
+++ b/src/Components/TeamMember.js
@@ -23,6 +23,10 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
     max-width: 240px;
     flex-direction: column;
     text-align: center;
+
+    @media (max-width: 375px) {
+      max-width: 167px;
+    }
   }
 
   &.teammember__name-container {
@@ -46,6 +50,10 @@ const Text = styled.p.attrs(() => ({ tabIndex: 0 }))`
   margin: 0 auto 0;
   padding; 0;
   width: fit-content;
+
+  @media (max-width: 375px) {
+    font-size: ${(props) => `${props.theme.fonts.text.sizes.text_xs}`};
+  }
 `;
 
 const Name = styled.span.attrs(() => ({ tabIndex: 0 }))`
@@ -54,10 +62,20 @@ const Name = styled.span.attrs(() => ({ tabIndex: 0 }))`
   margin: 0;
   padding; 0;
 
+  @media (max-width: 375px) {
+    font-size: ${(props) => `${props.theme.fonts.text.sizes.text_xs}`};
+    display: flex;
+    flex-direction: column;
+  }
+
   &.teammember__pronouns {
     width: fit-content;
     font-weight: ${(props) => `${props.theme.fonts.text.weights.normal}`};
     margin: 0;
+
+    @media (max-width: 375px) {
+      margin: 0 auto 0;
+    }
   }
 `;
 

--- a/src/Components/TeamMember.js
+++ b/src/Components/TeamMember.js
@@ -12,7 +12,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   margin: 0 auto 0;
   display: flex;
   flex-direction: column;
-  
+
   &.teammember__text-container {
     font-family: ${(props) => `${props.theme.fonts.text.font_family}`};
     font-size: ${(props) => `${props.theme.fonts.text.sizes.text_s}`};
@@ -26,6 +26,7 @@ const Container = styled.div.attrs(() => ({ tabIndex: 0 }))`
   }
 
   &.teammember__name-container {
+    width: fit-content;
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -50,7 +51,7 @@ const Text = styled.p.attrs(() => ({ tabIndex: 0 }))`
 const Name = styled.span.attrs(() => ({ tabIndex: 0 }))`
   font-weight: ${(props) => `${props.theme.fonts.text.weights.bold}`};
   width: fit-content;
-  margin: 0 3px 0 0;
+  margin: 0;
   padding; 0;
 
   &.teammember__pronouns {
@@ -61,19 +62,20 @@ const Name = styled.span.attrs(() => ({ tabIndex: 0 }))`
 `;
 
 const TeamMember = ({ photo, name, pronouns, headline }) => {
-
   return (
     <div className="teammember">
       <Container>
         <Photo src={photo} alt={name} />
         <Container className="teammember__text-container">
           <Container className="teammember__name-container">
-            <Name>{name}</Name>
-            <Name className="teammember__pronouns">
-              {pronouns ? pronouns : ""}
+            <Name>
+              {name}{" "}
+              <Name className="teammember__pronouns">
+                {pronouns ? pronouns : ""}
+              </Name>
             </Name>
           </Container>
-            <Text>{headline}</Text>
+          <Text>{headline}</Text>
         </Container>
       </Container>
     </div>

--- a/src/stories/OurStory.stories.js
+++ b/src/stories/OurStory.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import OurStory from '../Components/OurStory';
+import { customViewports } from '../../.storybook/preview';
 
 /**
  * The OurStory Story
@@ -10,8 +11,23 @@ import OurStory from '../Components/OurStory';
 export default {
     title: 'Our Story',
     component: OurStory,
+    parameters: {
+        viewport: {
+            viewports: customViewports,
+            defaultViewport: 'Desktop',
+        }
+    }
 };
 
-export const StoryTemplate = (args) => <OurStory {...args} />;
+export const StoryTemplate = () => <OurStory />;
+StoryTemplate.parameters = {
+    viewport: {
+        defaultViewport: 'Smaller_Desktop',
+    },
+};
 
-export const Primary = StoryTemplate.bind({});
+StoryTemplate.parameters = {
+    viewport: {
+        defaultViewport: 'iPhone_Mini',
+    },
+};


### PR DESCRIPTION
In this PR, I

- Adjusted the width of the default size of the `OurStory` component.
- Added max-widths `1024px` and `375px` CSS to `OurStory`, `Team`, and `Teammember`.
- Features such as the `Teammembers` component and the content portion of `OurStory` are using `1200px` as the screen size because that's where elements break and look funny. I did this to make the responsiveness transition smoother.
- Added viewports to `preview.js` so the different screen sizes can be previewed on `storybook`.

- NOTE: I took creative liberty to adjust how the names and pronouns of the team members look on the screen size `375px` to make it look less awkward.

- [ ✅ ]  Under 200 Lines
- [ ✅ ]  Tested and Works